### PR TITLE
Fix creating user with wrong UID

### DIFF
--- a/lib/features/signup/controllers/signup_controller.dart
+++ b/lib/features/signup/controllers/signup_controller.dart
@@ -27,9 +27,9 @@ class SignupController extends AutoDisposeNotifier<SignupState> {
     try {
       await _travelerRepo.checkUsernameAvailable(username);
 
-      await _travelerRepo.createProfile(username: username, email: email);
-
       await _authService.createUser(email: email, password: password);
+
+      await _travelerRepo.createProfile(username: username, email: email);
     } catch (e) {
       rethrow;
     } finally {

--- a/lib/infra/auth/service/firebase_auth_service.dart
+++ b/lib/infra/auth/service/firebase_auth_service.dart
@@ -29,7 +29,8 @@ class FirebaseAuthService implements AuthService {
     required String password,
   }) async {
     try {
-      await auth.createUserWithEmailAndPassword(email: email, password: password);
+      final emailProviderCredential = EmailAuthProvider.credential(email: email, password: password);
+      await _signInWithCredentialOrLinkUser(emailProviderCredential);
     } catch (e) {
       throw AuthResultHandler.handleException(e);
     }
@@ -59,6 +60,21 @@ class FirebaseAuthService implements AuthService {
   @override
   Future<void> logout() {
     return auth.signOut();
+  }
+
+  /// Signs in the user with a given [credential].
+  ///
+  /// In case the user is already logged in (namely, after signing in anonymously),
+  /// links the anonymous account with the `credential`
+  /// and converts the anonymous account into a permanent one.
+  /// Otherwise, creates a new account.
+  Future<UserCredential> _signInWithCredentialOrLinkUser(AuthCredential credential) {
+    if (auth.currentUser != null) {
+      // User signed in anonymously, link the acount
+      return auth.currentUser!.linkWithCredential(credential);
+    } else {
+      return auth.signInWithCredential(credential);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes an error where a new Firebase account, after already signing in anonymously, would be created with a different UID.

What happened:
1. User was automatically signed in as anon and given a UID
2. User tries to create an account with email
3. Firestore document is created with the anonymous UID
4. By calling `createUserWithEmailAndPassword`, a user is created with a **different** UID, resulting in a mismatch