### PR TITLE
Trip itinerary cards and planner home page

### DIFF
--- a/lib/features/home/controller/home_controller.dart
+++ b/lib/features/home/controller/home_controller.dart
@@ -6,7 +6,7 @@ final homeControllerProvider = NotifierProvider<HomeController, HomeState>(() =>
 class HomeController extends Notifier<HomeState> {
   @override
   HomeState build() {
-    return HomeState(page: SelectedHomePage.trips);
+    return const HomeState(page: SelectedHomePage.trips);
   }
 
   void selectPage(SelectedHomePage page) {

--- a/lib/features/home/view/home_page.dart
+++ b/lib/features/home/view/home_page.dart
@@ -30,8 +30,8 @@ class HomePage extends ConsumerWidget {
             label: 'Friends',
           ),
           NavigationDestination(
-            selectedIcon: Icon(Icons.manage_accounts_outlined),
-            icon: Icon(Icons.school_outlined),
+            selectedIcon: Icon(Icons.manage_accounts),
+            icon: Icon(Icons.manage_accounts_outlined),
             label: 'Account',
           ),
         ],

--- a/lib/features/home/view/home_page.dart
+++ b/lib/features/home/view/home_page.dart
@@ -1,7 +1,5 @@
 import 'package:cinnamon_riverpod_2/features/home/controller/home_controller.dart';
 import 'package:cinnamon_riverpod_2/features/home/controller/home_state.dart';
-import 'package:cinnamon_riverpod_2/infra/auth/service/firebase_auth_service.dart';
-import 'package:cinnamon_riverpod_2/infra/http/dio_http_service.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -39,7 +37,7 @@ class HomePage extends ConsumerWidget {
         ],
       ),
       body: <Widget>[
-        PlannerHomePage(),
+        const PlannerHomePage(),
         Container(
           color: Colors.green,
           alignment: Alignment.center,

--- a/lib/features/login/controllers/login_controller.dart
+++ b/lib/features/login/controllers/login_controller.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../infra/auth/service/auth_service.dart';
-import 'login_state.dart';
+import 'package:cinnamon_riverpod_2/infra/auth/service/auth_service.dart';
+import 'package:cinnamon_riverpod_2/features/login/controllers/login_state.dart';
 
 final loginControllerProvider = NotifierProvider.autoDispose<LoginController, LoginState>(
   () => LoginController(),

--- a/lib/features/login/view/login_page.dart
+++ b/lib/features/login/view/login_page.dart
@@ -10,7 +10,7 @@ import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../../shared/buttons/primary_button.dart';
+import 'package:cinnamon_riverpod_2/features/shared/buttons/primary_button.dart';
 
 class LoginPage extends HookConsumerWidget {
   const LoginPage({super.key});

--- a/lib/features/onboarding/controllers/onboarding_controller.dart
+++ b/lib/features/onboarding/controllers/onboarding_controller.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../routing/router.dart';
+import 'package:cinnamon_riverpod_2/routing/router.dart';
 
 final onboardingControllerProvider = StateNotifierProvider.autoDispose<OnboardingController, OnboardingState>(
   (ref) => OnboardingController(),

--- a/lib/features/onboarding/view/onboarding_page.dart
+++ b/lib/features/onboarding/view/onboarding_page.dart
@@ -6,8 +6,8 @@ import 'package:cinnamon_riverpod_2/theme/icons/app_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../shared/buttons/primary_button.dart';
-import '../controllers/onboarding_controller.dart';
+import 'package:cinnamon_riverpod_2/features/shared/buttons/primary_button.dart';
+import 'package:cinnamon_riverpod_2/features/onboarding/controllers/onboarding_controller.dart';
 
 class OnboardingPage extends ConsumerWidget {
   const OnboardingPage({super.key});

--- a/lib/features/onboarding/view/start_page.dart
+++ b/lib/features/onboarding/view/start_page.dart
@@ -3,10 +3,10 @@ import 'package:cinnamon_riverpod_2/gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../constants/enums.dart';
-import '../../../theme/icons/app_icons.dart';
-import '../../shared/buttons/secondary_button.dart';
-import '../controllers/onboarding_controller.dart';
+import 'package:cinnamon_riverpod_2/constants/enums.dart';
+import 'package:cinnamon_riverpod_2/theme/icons/app_icons.dart';
+import 'package:cinnamon_riverpod_2/features/shared/buttons/secondary_button.dart';
+import 'package:cinnamon_riverpod_2/features/onboarding/controllers/onboarding_controller.dart';
 
 class StartPage extends ConsumerWidget {
   const StartPage({super.key});

--- a/lib/features/planner/trips/controller/trip_planner_controller.dart
+++ b/lib/features/planner/trips/controller/trip_planner_controller.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
-
 import 'package:cinnamon_riverpod_2/features/planner/trips/controller/trip_planner_state.dart';
-//import 'package:cinnamon_riverpod_2/helpers/mixin/keep_alive_mixin.dart';
 import 'package:cinnamon_riverpod_2/infra/planner/model/trip_itinerary.dart';
 import 'package:cinnamon_riverpod_2/infra/planner/repository/trip_repository.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final tripPlannerControllerProvider = AutoDisposeAsyncNotifierProvider<TripPlannerController, TripPlannerState>(() {
@@ -23,17 +22,21 @@ class TripPlannerController extends AutoDisposeAsyncNotifier<TripPlannerState> {
       _trips?.cancel();
     });
 
-
     Future(() async {
       state = const AsyncLoading();
       await _trips?.cancel();
 
       _trips = ref.watch(tripRepositoryProvider).getTripItineraries().listen((event) {
-        state = AsyncData(TripPlannerState(itineraries: event.toList()));
+        // Split itineraries into current and upcoming
+        final currentItineraries = event.where((element) => element.isCurrent).toList();
+        final upcomingItineraries =
+            event.where((element) => element.isUpcoming).sortedBy((element) => element.startDate).toList();
+
+        state = AsyncData(TripPlannerState(itineraries: currentItineraries, upcomingItineraries: upcomingItineraries));
       });
     });
 
-    return const TripPlannerState(itineraries: []);
+    return const TripPlannerState(itineraries: [], upcomingItineraries: []);
   }
 
   Future<void> createMocked() async {

--- a/lib/features/planner/trips/controller/trip_planner_state.dart
+++ b/lib/features/planner/trips/controller/trip_planner_state.dart
@@ -1,14 +1,15 @@
 import 'package:cinnamon_riverpod_2/infra/planner/model/trip_itinerary.dart';
-import 'package:cinnamon_riverpod_2/infra/planner/model/trip_location.dart';
 import 'package:equatable/equatable.dart';
 
 class TripPlannerState extends Equatable {
   final List<TripItinerary> itineraries;
+  final List<TripItinerary> upcomingItineraries;
 
   const TripPlannerState({
     required this.itineraries,
+    required this.upcomingItineraries,
   });
 
   @override
-  List<Object?> get props => [itineraries];
+  List<Object?> get props => [itineraries, upcomingItineraries];
 }

--- a/lib/features/planner/trips/planner_home_page.dart
+++ b/lib/features/planner/trips/planner_home_page.dart
@@ -1,22 +1,76 @@
+import 'package:cinnamon_riverpod_2/features/planner/trips/widgets/no_trips_placeholder.dart';
+import 'package:cinnamon_riverpod_2/features/planner/trips/widgets/planner_app_bar.dart';
+import 'package:cinnamon_riverpod_2/features/planner/trips/widgets/trip_section.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
+import '../../shared/buttons/rounded_icon_button.dart';
 import 'controller/trip_planner_controller.dart';
 
 class PlannerHomePage extends ConsumerWidget {
-  const PlannerHomePage({Key? key}) : super(key: key);
+  const PlannerHomePage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.read(tripPlannerControllerProvider.notifier);
     final state = ref.watch(tripPlannerControllerProvider);
+
     return Scaffold(
-        primary: false,
-        floatingActionButton: FloatingActionButton(
-          onPressed: () {
-            ref.read(tripPlannerControllerProvider.notifier).createMocked();
+      primary: false,
+      appBar: PlannerAppBar(
+        title: 'Trips',
+        actions: [
+          SizedBox(
+            width: 32,
+            height: 32,
+            child: RoundedIconButton(
+              icon: CupertinoIcons.add,
+              size: 32.0,
+              onPressed: controller.createMocked,
+              tooltipMessage: 'Plan new trip',
+            ),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: state.when(
+          data: (plannerState) {
+            final currentItineraries = plannerState.itineraries;
+            final upcomingItineraries = plannerState.upcomingItineraries;
+
+            if (currentItineraries.isEmpty && upcomingItineraries.isEmpty) {
+              return const Center(child: NoTripsPlaceholder());
+            }
+
+            return SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Column(
+                  children: [
+                    TripSection(
+                      sectionTitle: 'Current trip',
+                      emptyMessage: 'No trip in progress',
+                      itineraries: currentItineraries,
+                    ),
+                    const SizedBox(
+                      height: 24,
+                    ),
+                    TripSection(
+                      sectionTitle:
+                          'Upcoming trips ${upcomingItineraries.isNotEmpty ? "(${upcomingItineraries.length})" : ""}',
+                      emptyMessage: "You don't have any upcoming trips",
+                      itineraries: upcomingItineraries,
+                    ),
+                  ],
+                ),
+              ),
+            );
           },
-          child: const Icon(Icons.add),
+          error: (error, _) => Text(error.toString()),
+          loading: CircularProgressIndicator.adaptive,
         ),
-        body: Text(state.toString()));
+      ),
+    );
   }
 }

--- a/lib/features/planner/trips/planner_home_page.dart
+++ b/lib/features/planner/trips/planner_home_page.dart
@@ -17,7 +17,7 @@ class PlannerHomePage extends ConsumerWidget {
     final state = ref.watch(tripPlannerControllerProvider);
 
     return Scaffold(
-      primary: false,
+      primary: true,
       appBar: PlannerAppBar(
         title: 'Trips',
         actions: [

--- a/lib/features/planner/trips/planner_home_page.dart
+++ b/lib/features/planner/trips/planner_home_page.dart
@@ -1,6 +1,7 @@
 import 'package:cinnamon_riverpod_2/features/planner/trips/widgets/no_trips_placeholder.dart';
 import 'package:cinnamon_riverpod_2/features/planner/trips/widgets/planner_app_bar.dart';
 import 'package:cinnamon_riverpod_2/features/planner/trips/widgets/trip_section.dart';
+import 'package:cinnamon_riverpod_2/features/shared/adaptive_progress_indicator.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -68,7 +69,9 @@ class PlannerHomePage extends ConsumerWidget {
             );
           },
           error: (error, _) => Text(error.toString()),
-          loading: CircularProgressIndicator.adaptive,
+          loading: () => const Center(
+            child: AdaptiveProgressIndicator(),
+          ),
         ),
       ),
     );

--- a/lib/features/planner/trips/widgets/no_trips_placeholder.dart
+++ b/lib/features/planner/trips/widgets/no_trips_placeholder.dart
@@ -1,0 +1,31 @@
+import 'package:cinnamon_riverpod_2/gen/assets.gen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class NoTripsPlaceholder extends StatelessWidget {
+  const NoTripsPlaceholder({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) => Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SvgPicture.asset(
+            Assets.images.journey,
+            width: 100,
+            height: 100,
+            fit: BoxFit.contain,
+          ),
+          const SizedBox(height: 32),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 32),
+            child: Text(
+              "You don't have any trips. Go and plan some!",
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+        ],
+      );
+}

--- a/lib/features/planner/trips/widgets/planner_app_bar.dart
+++ b/lib/features/planner/trips/widgets/planner_app_bar.dart
@@ -7,7 +7,7 @@ class PlannerAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
   final List<Widget> actions;
 
-  const PlannerAppBar({
+  PlannerAppBar({
     super.key,
     required this.title,
     required this.actions,
@@ -40,7 +40,9 @@ class PlannerAppBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 
-  double get preferredHeight => 120;
+  final _appbar = AppBar();
+
+  double get preferredHeight => _appbar.preferredSize.height;
 
   @override
   Size get preferredSize => Size.fromHeight(preferredHeight);

--- a/lib/features/planner/trips/widgets/planner_app_bar.dart
+++ b/lib/features/planner/trips/widgets/planner_app_bar.dart
@@ -1,1 +1,47 @@
+import 'package:flutter/material.dart';
 
+import '../../../../gen/assets.gen.dart';
+import '../../../../theme/icons/app_icons.dart';
+
+class PlannerAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final List<Widget> actions;
+
+  const PlannerAppBar({
+    super.key,
+    required this.title,
+    required this.actions,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      automaticallyImplyLeading: false,
+      leading: Padding(
+        padding: const EdgeInsets.only(left: 16),
+        child: Row(
+          children: [
+            AppIcons.icon(
+              Assets.icons.earthPlane,
+              size: 32.0,
+              color: Theme.of(context).primaryColor,
+            ),
+          ],
+        ),
+      ),
+      actions: actions
+          .map(
+            (actionWidget) => Padding(
+              padding: const EdgeInsets.only(right: 16),
+              child: actionWidget,
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  double get preferredHeight => 120;
+
+  @override
+  Size get preferredSize => Size.fromHeight(preferredHeight);
+}

--- a/lib/features/planner/trips/widgets/planner_app_bar.dart
+++ b/lib/features/planner/trips/widgets/planner_app_bar.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-
-import '../../../../gen/assets.gen.dart';
-import '../../../../theme/icons/app_icons.dart';
+import 'package:cinnamon_riverpod_2/gen/assets.gen.dart';
+import 'package:cinnamon_riverpod_2/theme/icons/app_icons.dart';
 
 class PlannerAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;

--- a/lib/features/planner/trips/widgets/trip_itinerary_card.dart
+++ b/lib/features/planner/trips/widgets/trip_itinerary_card.dart
@@ -1,0 +1,142 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cinnamon_riverpod_2/features/shared/buttons/tertiary_button.dart';
+import 'package:cinnamon_riverpod_2/helpers/helper_extensions.dart';
+import 'package:cinnamon_riverpod_2/infra/planner/model/trip_itinerary.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class TripItineraryCard extends StatelessWidget {
+  final TripItinerary itinerary;
+
+  const TripItineraryCard({
+    super.key,
+    required this.itinerary,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 184,
+      width: double.infinity,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: context.theme.shadowColor,
+            spreadRadius: 5,
+            blurRadius: 7,
+            offset: const Offset(0, 3),
+          ),
+        ],
+      ),
+      child: Stack(
+        children: [
+          Stack(
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: CachedNetworkImage(
+                  imageUrl: itinerary.imageUrl!,
+                  fit: BoxFit.fitWidth,
+                  width: double.infinity,
+                ),
+              ),
+              Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8),
+                  color: Colors.white,
+                  gradient: LinearGradient(
+                    colors: [Colors.black.withOpacity(0.5), Colors.transparent, Colors.black.withOpacity(0.7)],
+                    begin: const FractionalOffset(0, 0),
+                    end: const FractionalOffset(0, 1),
+                    stops: const [0.0, 0.5, 1.0],
+                  ),
+                ),
+              ),
+            ],
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      itinerary.name,
+                      style: context.theme.textTheme.headlineSmall
+                          ?.copyWith(color: Colors.white, fontWeight: FontWeight.w900),
+                    ),
+                    Text(
+                      "${itinerary.startDate.dateString} - ${itinerary.endDate.dateString}",
+                      style: context.theme.textTheme.bodyMedium?.copyWith(color: Colors.white),
+                    ),
+                  ],
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        IconRowWidget(
+                          icon: CupertinoIcons.location_solid,
+                          text: "${itinerary.locations.length} locations",
+                        ),
+                        IconRowWidget(
+                          icon: CupertinoIcons.group_solid,
+                          text: "${itinerary.travelers.length} travellers",
+                        ),
+                      ],
+                    ),
+                    SizedBox(
+                      width: 110,
+                      child: TertiaryButton(
+                        text: 'More >',
+                        onPressed: () {},
+                      ),
+                    ),
+                  ],
+                )
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class IconRowWidget extends StatelessWidget {
+  final IconData icon;
+  final String text;
+
+  const IconRowWidget({
+    super.key,
+    required this.icon,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(
+          icon,
+          size: 16,
+          color: Colors.white,
+        ),
+        const SizedBox(
+          width: 8,
+        ),
+        Text(
+          text,
+          style: context.theme.textTheme.bodyMedium?.copyWith(color: Colors.white),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/planner/trips/widgets/trip_section.dart
+++ b/lib/features/planner/trips/widgets/trip_section.dart
@@ -1,0 +1,51 @@
+import 'package:cinnamon_riverpod_2/features/planner/trips/widgets/trip_itinerary_card.dart';
+import 'package:cinnamon_riverpod_2/helpers/helper_extensions.dart';
+import 'package:cinnamon_riverpod_2/infra/planner/model/trip_itinerary.dart';
+import 'package:flutter/material.dart';
+
+class TripSection extends StatelessWidget {
+  final String sectionTitle;
+  final String emptyMessage;
+  final List<TripItinerary> itineraries;
+
+  const TripSection({
+    super.key,
+    required this.sectionTitle,
+    required this.emptyMessage,
+    required this.itineraries,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 24, bottom: 16),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              Text(
+                sectionTitle,
+                style: context.theme.textTheme.headlineSmall,
+              ),
+            ],
+          ),
+        ),
+        if (itineraries.isEmpty)
+          Text(
+            emptyMessage,
+            style: context.theme.textTheme.bodyMedium?.copyWith(color: Colors.grey.shade500),
+          ),
+        ListView.separated(
+          itemBuilder: (_, index) => TripItineraryCard(itinerary: itineraries[index]),
+          separatorBuilder: (_, __) => const SizedBox(
+            height: 16,
+          ),
+          itemCount: itineraries.length,
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/shared/adaptive_progress_indicator.dart
+++ b/lib/features/shared/adaptive_progress_indicator.dart
@@ -1,0 +1,18 @@
+import 'package:cinnamon_riverpod_2/helpers/helper_extensions.dart';
+import 'package:flutter/material.dart';
+
+class AdaptiveProgressIndicator extends StatelessWidget {
+  final Color? customColor;
+
+  const AdaptiveProgressIndicator({
+    super.key,
+    this.customColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CircularProgressIndicator.adaptive(
+      backgroundColor: customColor ?? context.theme.primaryColor,
+    );
+  }
+}

--- a/lib/features/shared/buttons/rounded_icon_button.dart
+++ b/lib/features/shared/buttons/rounded_icon_button.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class RoundedIconButton extends StatelessWidget {
+  final IconData icon;
+  final VoidCallback? onPressed;
+  final Color? color;
+  final double size;
+  final String? tooltipMessage;
+
+  const RoundedIconButton({
+    super.key,
+    required this.icon,
+    this.onPressed,
+    this.color,
+    this.size = 56.0,
+    this.tooltipMessage,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltipMessage ?? '',
+      child: TextButton(
+        onPressed: onPressed,
+        style: TextButton.styleFrom(
+          backgroundColor: color,
+          foregroundColor: Theme.of(context).scaffoldBackgroundColor,
+          shape: const CircleBorder(),
+          fixedSize: Size(size, size),
+        ),
+        child: Icon(icon),
+      ),
+    );
+  }
+}

--- a/lib/features/shared/buttons/tertiary_button.dart
+++ b/lib/features/shared/buttons/tertiary_button.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class TertiaryButton extends StatelessWidget {
+  final String text;
+  final VoidCallback? onPressed;
+  final bool isDisabled;
+
+  const TertiaryButton({
+    super.key,
+    required this.text,
+    this.onPressed,
+    this.isDisabled = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton(
+      onPressed: isDisabled ? null : onPressed,
+      child: Text(text),
+    );
+  }
+}

--- a/lib/features/signup/controllers/signup_state.dart
+++ b/lib/features/signup/controllers/signup_state.dart
@@ -15,7 +15,7 @@ class SignupState extends Equatable {
   }) {
     return SignupState(
       allFieldsValid: allFieldsValid ?? this.allFieldsValid,
-      isLoading: loading ?? this.isLoading,
+      isLoading: loading ?? isLoading,
     );
   }
 

--- a/lib/features/signup/view/signup_page.dart
+++ b/lib/features/signup/view/signup_page.dart
@@ -11,7 +11,7 @@ import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import '../../shared/buttons/primary_button.dart';
+import 'package:cinnamon_riverpod_2/features/shared/buttons/primary_button.dart';
 
 class SignupPage extends HookConsumerWidget {
   const SignupPage({super.key});

--- a/lib/helpers/helper_extensions.dart
+++ b/lib/helpers/helper_extensions.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+extension BuildContextExt on BuildContext {
+  Size get size => MediaQuery.sizeOf(this);
+
+  ThemeData get theme => Theme.of(this);
+}
+
+extension DateTimeExt on DateTime {
+  /// Extracts just the date from [this] DateTime.
+  DateTime get date => DateTime(year, month, day);
+
+  /// Formats [this] in a `dd.MM.yyyy.` format.
+  String get dateString => DateFormat("dd.MM.yyyy.").format(this);
+}

--- a/lib/infra/auth/service/auth_service.dart
+++ b/lib/infra/auth/service/auth_service.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'firebase_auth_service.dart';
+import 'package:cinnamon_riverpod_2/infra/auth/service/firebase_auth_service.dart';
 
 final authServiceProvider = Provider((ref) => FirebaseAuthService());
 
@@ -54,5 +54,4 @@ abstract interface class AuthService {
 
   /// Deletes current user's account.
   Future<void> deleteAccount();
-
 }

--- a/lib/infra/planner/entity/trip_itinerary.dart
+++ b/lib/infra/planner/entity/trip_itinerary.dart
@@ -8,6 +8,8 @@ class TripItineraryEntity {
   final String? imageUrl;
   final List<TripLocationEntity> locations;
   final List<String> ownerIds;
+  final DateTime startDate;
+  final DateTime endDate;
 
   const TripItineraryEntity({
     required this.id,
@@ -16,6 +18,8 @@ class TripItineraryEntity {
     this.imageUrl,
     required this.locations,
     required this.ownerIds,
+    required this.startDate,
+    required this.endDate,
   });
 
   factory TripItineraryEntity.fromDoc(DocumentSnapshot doc) {
@@ -26,6 +30,8 @@ class TripItineraryEntity {
       imageUrl: doc['imageUrl'],
       locations: (doc['locations'] as List).map((e) => TripLocationEntity.fromMap(e)).toList(),
       ownerIds: (doc['ownerIds'] as List).map((e) => e.toString()).toList(),
+      startDate: DateTime.parse(doc['startDate'] as String),
+      endDate: DateTime.parse(doc['endDate'] as String),
     );
   }
 
@@ -37,6 +43,8 @@ class TripItineraryEntity {
       'imageUrl': imageUrl,
       'locations': locations.map((e) => e.toMap()).toList(),
       'ownerIds': ownerIds,
+      'startDate': startDate.toIso8601String(),
+      'endDate': endDate.toIso8601String(),
     };
   }
 }

--- a/lib/infra/planner/model/trip_itinerary.dart
+++ b/lib/infra/planner/model/trip_itinerary.dart
@@ -11,14 +11,18 @@ class TripItinerary extends Equatable {
   final String? imageUrl;
   final List<TripLocation> locations;
   final List<CoTraveler> travelers;
+  final DateTime startDate;
+  final DateTime endDate;
 
-  TripItinerary({
+  const TripItinerary({
     required this.id,
     required this.name,
     required this.description,
     this.imageUrl,
     required this.locations,
     required this.travelers,
+    required this.startDate,
+    required this.endDate,
   });
 
   factory TripItinerary.fromEntity(TripItineraryEntity entity, List<TravelerEntity> travelers) {
@@ -29,9 +33,23 @@ class TripItinerary extends Equatable {
       imageUrl: entity.imageUrl,
       locations: entity.locations.map((e) => TripLocation.fromEntity(e)).toList(),
       travelers: travelers.map((e) => CoTraveler.fromEntity(e)).toList(),
+      startDate: entity.startDate,
+      endDate: entity.endDate,
     );
   }
 
   @override
-  List<Object?> get props => [id, name, description, imageUrl, locations, travelers];
+  List<Object?> get props => [id, name, description, imageUrl, locations, travelers, startDate, endDate];
+
+  bool get isCurrent {
+    final now = DateTime.now();
+
+    return now.isAfter(startDate) && now.isBefore(endDate);
+  }
+
+  bool get isUpcoming {
+    final now = DateTime.now();
+
+    return now.isBefore(startDate);
+  }
 }

--- a/lib/infra/planner/repository/trip_repository.dart
+++ b/lib/infra/planner/repository/trip_repository.dart
@@ -3,18 +3,14 @@ import 'package:cinnamon_riverpod_2/infra/planner/model/trip_itinerary.dart';
 import 'package:cinnamon_riverpod_2/infra/planner/repository/trip_repository_implementation.dart';
 import 'package:cinnamon_riverpod_2/infra/traveler/data_source/traveler_data_source.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cinnamon_riverpod_2/infra/auth/service/firebase_auth_service.dart';
 
-import '../../auth/service/firebase_auth_service.dart';
-
-final Provider<TripRepository> tripRepositoryProvider =
-    Provider<TripRepository>((ProviderRef<TripRepository> ref) {
+final Provider<TripRepository> tripRepositoryProvider = Provider<TripRepository>((ProviderRef<TripRepository> ref) {
   final String userId = ref.watch(userIdProvider);
   final TripDataSource tripDataSource = ref.watch(tripDataSourceProvider);
-  final TravelerDataSource travelerDataSource =
-      ref.watch(travelerDataSourceProvider);
+  final TravelerDataSource travelerDataSource = ref.watch(travelerDataSourceProvider);
 
-  return TripRepositoryImplementation(
-      tripDataSource, travelerDataSource, userId);
+  return TripRepositoryImplementation(tripDataSource, travelerDataSource, userId);
 });
 
 abstract interface class TripRepository {

--- a/lib/infra/planner/repository/trip_repository_implementation.dart
+++ b/lib/infra/planner/repository/trip_repository_implementation.dart
@@ -33,6 +33,17 @@ class TripRepositoryImplementation with EquatableMixin implements TripRepository
   @override
   Future<void> createMocked() {
     return _tripDataSource.createTrip(
-        TripItineraryEntity(id: "id", name: "name", description: "description", locations: [], ownerIds: [_userId]),);
+      TripItineraryEntity(
+        id: "01",
+        name: "Trip to Zagreb",
+        description: "Going to ZG, HR",
+        locations: [],
+        ownerIds: [_userId],
+        imageUrl:
+            'https://images.unsplash.com/photo-1572455044327-7348c1be7267?auto=format&fit=crop&q=80&w=3603&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+        startDate: DateTime(2024, 2, 1),
+        endDate: DateTime(2024, 2, 15),
+      ),
+    );
   }
 }

--- a/lib/infra/traveler/model/cotraveler.dart
+++ b/lib/infra/traveler/model/cotraveler.dart
@@ -4,7 +4,7 @@ import 'package:equatable/equatable.dart';
 class CoTraveler extends Equatable {
   final String name;
 
-  CoTraveler(this.name);
+  const CoTraveler(this.name);
 
   factory CoTraveler.fromEntity(TravelerEntity entity) {
     return CoTraveler(entity.username);

--- a/lib/infra/traveler/model/traveler.dart
+++ b/lib/infra/traveler/model/traveler.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 
-import '../entity/traveler_entity.dart';
+import 'package:cinnamon_riverpod_2/infra/traveler/entity/traveler_entity.dart';
 
 class Traveler extends Equatable {
   final String name;

--- a/lib/theme/colors/dark_app_colors.dart
+++ b/lib/theme/colors/dark_app_colors.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-
-import 'app_colors.dart';
+import 'package:cinnamon_riverpod_2/theme/colors/app_colors.dart';
 
 final darkAppColors = DarkAppColors();
 

--- a/lib/theme/colors/light_app_colors.dart
+++ b/lib/theme/colors/light_app_colors.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-
-import 'app_colors.dart';
+import 'package:cinnamon_riverpod_2/theme/colors/app_colors.dart';
 
 final lightAppColors = LightAppColors();
 

--- a/lib/theme/styles/app_text_styles.dart
+++ b/lib/theme/styles/app_text_styles.dart
@@ -8,6 +8,8 @@ abstract class AppTextStyles {
 
   TextStyle get headlineLargeTextStyle;
 
+  TextStyle get headlineMediumTextStyle;
+
   TextStyle get headlineSmallTextStyle;
 
   TextStyle get bodyLargeTextStyle;

--- a/lib/theme/styles/dark_app_text_styles.dart
+++ b/lib/theme/styles/dark_app_text_styles.dart
@@ -27,6 +27,13 @@ final class DarkAppTextStyles extends AppTextStyles {
       );
 
   @override
+  TextStyle get headlineMediumTextStyle => TextStyle(
+        fontSize: 24,
+        fontWeight: FontWeight.w800,
+        color: lightAppColors.backgroundColor,
+      );
+
+  @override
   TextStyle get headlineSmallTextStyle => TextStyle(
         fontSize: 18,
         color: lightAppColors.backgroundColor,

--- a/lib/theme/styles/light_app_text_styles.dart
+++ b/lib/theme/styles/light_app_text_styles.dart
@@ -27,6 +27,13 @@ class LightAppTextStyles extends AppTextStyles {
       );
 
   @override
+  TextStyle get headlineMediumTextStyle => TextStyle(
+        fontSize: 24,
+        fontWeight: FontWeight.w800,
+        color: darkAppColors.backgroundColor,
+      );
+
+  @override
   TextStyle get headlineSmallTextStyle => TextStyle(
         fontSize: 18,
         color: darkAppColors.backgroundColor,

--- a/lib/theme/theme.dart
+++ b/lib/theme/theme.dart
@@ -9,210 +9,271 @@ import 'package:flutter/material.dart';
 final appTheme = AppTheme();
 
 class AppTheme {
-    ThemeData get lightTheme => ThemeData(
-    fontFamily: FontFamily.manrope,
+  ThemeData get lightTheme => ThemeData(
+        fontFamily: FontFamily.manrope,
 
-    primaryColor: lightAppColors.primary100,
-    scaffoldBackgroundColor: lightAppColors.backgroundColor,
-    dialogBackgroundColor: Colors.white,
+        /// COLORS
+        primaryColor: lightAppColors.primary100,
+        scaffoldBackgroundColor: lightAppColors.backgroundColor,
+        dialogBackgroundColor: Colors.white,
+        shadowColor: lightAppColors.neutrals800.withOpacity(0.2),
 
-    /// TRANSITION
-    pageTransitionsTheme: const PageTransitionsTheme(
-      builders: {
-        TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
-        TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
-      },
-    ),
+        /// TRANSITION
+        pageTransitionsTheme: const PageTransitionsTheme(
+          builders: {
+            TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
+            TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+          },
+        ),
 
-    /// BUTTONS
-    textButtonTheme: TextButtonThemeData(
-      style: TextButton.styleFrom(
-        backgroundColor: lightAppColors.primary100,
-        foregroundColor: lightAppColors.primaryDark,
-        disabledBackgroundColor: lightAppColors.primary600,
-        disabledForegroundColor: lightAppColors.neutralsWhite,
-        textStyle: lightAppTextStyles.primaryButtonTextStyle,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        /// BUTTONS
+        textButtonTheme: TextButtonThemeData(
+          style: TextButton.styleFrom(
+            backgroundColor: lightAppColors.primary100,
+            foregroundColor: lightAppColors.primaryDark,
+            disabledBackgroundColor: lightAppColors.primary600,
+            disabledForegroundColor: lightAppColors.neutralsWhite,
+            textStyle: lightAppTextStyles.primaryButtonTextStyle,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            splashFactory:
+                defaultTargetPlatform == TargetPlatform.android ? InkSparkle.splashFactory : NoSplash.splashFactory,
+          ),
+        ),
+        filledButtonTheme: FilledButtonThemeData(
+          style: TextButton.styleFrom(
+            backgroundColor: lightAppColors.primary500,
+            foregroundColor: lightAppColors.primaryDark,
+            disabledBackgroundColor: lightAppColors.neutrals700,
+            disabledForegroundColor: lightAppColors.neutrals800,
+            textStyle: darkAppTextStyles.primaryButtonTextStyle,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            splashFactory:
+                defaultTargetPlatform == TargetPlatform.android ? InkSparkle.splashFactory : NoSplash.splashFactory,
+          ),
+        ),
+        outlinedButtonTheme: OutlinedButtonThemeData(
+          style: OutlinedButton.styleFrom(
+            side: const BorderSide(color: Colors.white),
+            foregroundColor: Colors.white,
+            textStyle: darkAppTextStyles.primaryButtonTextStyle,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            splashFactory:
+                defaultTargetPlatform == TargetPlatform.android ? InkSparkle.splashFactory : NoSplash.splashFactory,
+          ),
+        ),
+
+        /// SPLASHES
         splashFactory:
             defaultTargetPlatform == TargetPlatform.android ? InkSparkle.splashFactory : NoSplash.splashFactory,
-      ),
-    ),
-    filledButtonTheme: FilledButtonThemeData(
-      style: TextButton.styleFrom(
-        backgroundColor: lightAppColors.primary500,
-        foregroundColor: lightAppColors.primaryDark,
-        disabledBackgroundColor: lightAppColors.neutrals700,
-        disabledForegroundColor: lightAppColors.neutrals800,
-        textStyle: darkAppTextStyles.primaryButtonTextStyle,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        splashColor: lightAppColors.primary300,
+
+        /// TEXT
+        textTheme: TextTheme(
+          titleMedium: lightAppTextStyles.titleMediumTextStyle,
+          headlineLarge: lightAppTextStyles.headlineLargeTextStyle,
+          headlineMedium: lightAppTextStyles.headlineMediumTextStyle,
+          headlineSmall: lightAppTextStyles.headlineSmallTextStyle,
+          bodyLarge: lightAppTextStyles.bodyLargeTextStyle,
+          bodyMedium: lightAppTextStyles.bodyMediumTextStyle,
+          bodySmall: lightAppTextStyles.bodySmallTextStyle,
+          labelMedium: lightAppTextStyles.labelMediumTextStyle,
+        ),
+
+        /// INPUTS
+        inputDecorationTheme: InputDecorationTheme(
+          floatingLabelStyle: TextStyle(
+            color: lightAppColors.primary100,
+          ),
+          hintStyle: TextStyle(color: darkAppColors.backgroundColor),
+          labelStyle: TextStyle(color: darkAppColors.backgroundColor),
+          contentPadding: const EdgeInsets.all(20),
+          iconColor: lightAppColors.primary100,
+          enabledBorder: OutlineInputBorder(
+            borderSide: BorderSide.none,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderSide: BorderSide(
+              color: darkAppColors.primary100,
+            ),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          errorBorder: OutlineInputBorder(
+            borderSide: BorderSide(
+              color: lightAppColors.error,
+            ),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          focusedErrorBorder: OutlineInputBorder(
+            borderSide: BorderSide(
+              color: lightAppColors.error,
+            ),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          errorStyle: TextStyle(color: lightAppColors.error),
+          filled: true,
+          fillColor: lightAppColors.neutralsWhite,
+        ),
+
+        /// SNACKBAR
+        snackBarTheme: SnackBarThemeData(
+          behavior: SnackBarBehavior.floating,
+          backgroundColor: lightAppColors.primaryDark,
+          insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          contentTextStyle: lightAppTextStyles.bodyMediumTextStyle.copyWith(color: lightAppColors.neutralsWhite),
+        ),
+
+        /// APP BARS
+        appBarTheme: AppBarTheme(
+          color: lightAppColors.backgroundColor,
+          shadowColor: Colors.black.withOpacity(0.3),
+          titleTextStyle: lightAppTextStyles.labelMediumTextStyle.copyWith(color: lightAppColors.primaryDark),
+        ),
+        navigationBarTheme: NavigationBarThemeData(
+          backgroundColor: lightAppColors.backgroundColor,
+          indicatorColor: lightAppColors.primary100,
+          labelTextStyle: MaterialStateProperty.resolveWith(
+            (states) => lightAppTextStyles.bodyMediumTextStyle
+                .copyWith(color: states.contains(MaterialState.selected) ? lightAppColors.primary100 : null),
+          ),
+          iconTheme: MaterialStateProperty.resolveWith(
+            (states) => IconThemeData(color: darkAppColors.backgroundColor),
+          ),
+        ),
+      );
+
+  ThemeData get darkTheme => ThemeData(
+        fontFamily: FontFamily.manrope,
+
+        /// COLORS
+        primaryColor: darkAppColors.primary100,
+        scaffoldBackgroundColor: darkAppColors.backgroundColor,
+        dialogBackgroundColor: Colors.black,
+        shadowColor: darkAppColors.neutrals800.withOpacity(0.1),
+
+        /// TRANSITION
+        pageTransitionsTheme: const PageTransitionsTheme(
+          builders: {
+            TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
+            TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+          },
+        ),
+
+        /// BUTTONS
+        textButtonTheme: TextButtonThemeData(
+          style: TextButton.styleFrom(
+            backgroundColor: darkAppColors.primary100,
+            foregroundColor: darkAppColors.neutralsWhite,
+            disabledBackgroundColor: lightAppColors.primary300,
+            disabledForegroundColor: lightAppColors.primary600,
+            textStyle: darkAppTextStyles.primaryButtonTextStyle,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            splashFactory:
+                defaultTargetPlatform == TargetPlatform.android ? InkSparkle.splashFactory : NoSplash.splashFactory,
+          ),
+        ),
+        filledButtonTheme: FilledButtonThemeData(
+          style: TextButton.styleFrom(
+            backgroundColor: darkAppColors.primary300,
+            foregroundColor: darkAppColors.neutralsWhite,
+            disabledBackgroundColor: lightAppColors.neutrals700,
+            disabledForegroundColor: lightAppColors.neutrals800,
+            textStyle: darkAppTextStyles.primaryButtonTextStyle,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            splashFactory:
+                defaultTargetPlatform == TargetPlatform.android ? InkSparkle.splashFactory : NoSplash.splashFactory,
+          ),
+        ),
+        outlinedButtonTheme: OutlinedButtonThemeData(
+          style: OutlinedButton.styleFrom(
+            side: const BorderSide(color: Colors.white),
+            foregroundColor: Colors.white,
+            textStyle: darkAppTextStyles.primaryButtonTextStyle,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+            splashFactory:
+                defaultTargetPlatform == TargetPlatform.android ? InkSparkle.splashFactory : NoSplash.splashFactory,
+          ),
+        ),
+
+        /// SPLASHES
         splashFactory:
             defaultTargetPlatform == TargetPlatform.android ? InkSparkle.splashFactory : NoSplash.splashFactory,
-      ),
-    ),
+        splashColor: darkAppColors.primary300,
 
-    /// SPLASHES
-    splashFactory: defaultTargetPlatform == TargetPlatform.android ? InkSparkle.splashFactory : NoSplash.splashFactory,
-    splashColor: lightAppColors.primary300,
-
-    /// TEXT
-    textTheme: TextTheme(
-      titleMedium: lightAppTextStyles.titleMediumTextStyle,
-      headlineLarge: lightAppTextStyles.headlineLargeTextStyle,
-      headlineSmall: lightAppTextStyles.headlineSmallTextStyle,
-      bodyLarge: lightAppTextStyles.bodyLargeTextStyle,
-      bodyMedium: lightAppTextStyles.bodyMediumTextStyle,
-      bodySmall: lightAppTextStyles.bodySmallTextStyle,
-      labelMedium: lightAppTextStyles.labelMediumTextStyle,
-    ),
-
-    /// INPUTS
-    inputDecorationTheme: InputDecorationTheme(
-      floatingLabelStyle: TextStyle(
-        color: lightAppColors.primary100,
-      ),
-      hintStyle: TextStyle(color: darkAppColors.backgroundColor),
-      labelStyle: TextStyle(color: darkAppColors.backgroundColor),
-      contentPadding: const EdgeInsets.all(20),
-      iconColor: lightAppColors.primary100,
-      enabledBorder: OutlineInputBorder(
-        borderSide: BorderSide.none,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      focusedBorder: OutlineInputBorder(
-        borderSide: BorderSide(
-          color: darkAppColors.primary100,
+        /// TEXT
+        textTheme: TextTheme(
+          titleMedium: darkAppTextStyles.titleMediumTextStyle,
+          headlineLarge: darkAppTextStyles.headlineLargeTextStyle,
+          headlineMedium: darkAppTextStyles.headlineMediumTextStyle,
+          headlineSmall: darkAppTextStyles.headlineSmallTextStyle,
+          bodyLarge: darkAppTextStyles.bodyLargeTextStyle,
+          bodyMedium: darkAppTextStyles.bodyMediumTextStyle,
+          bodySmall: darkAppTextStyles.bodySmallTextStyle,
+          labelMedium: darkAppTextStyles.labelMediumTextStyle,
         ),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      errorBorder: OutlineInputBorder(
-        borderSide: BorderSide(
-          color: lightAppColors.error,
+
+        /// INPUTS
+        inputDecorationTheme: InputDecorationTheme(
+          floatingLabelStyle: TextStyle(
+            color: lightAppColors.primary100,
+          ),
+          hintStyle: TextStyle(color: lightAppColors.backgroundColor),
+          labelStyle: TextStyle(color: lightAppColors.backgroundColor),
+          contentPadding: const EdgeInsets.all(20),
+          iconColor: lightAppColors.primary100,
+          enabledBorder: OutlineInputBorder(
+            borderSide: BorderSide.none,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderSide: BorderSide(
+              color: darkAppColors.primary100,
+            ),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          errorBorder: OutlineInputBorder(
+            borderSide: BorderSide(
+              color: darkAppColors.error,
+            ),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          focusedErrorBorder: OutlineInputBorder(
+            borderSide: BorderSide(
+              color: darkAppColors.error,
+            ),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          errorStyle: TextStyle(color: darkAppColors.error),
+          filled: true,
+          fillColor: lightAppColors.neutrals900,
         ),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      focusedErrorBorder: OutlineInputBorder(
-        borderSide: BorderSide(
-          color: lightAppColors.error,
+
+        /// SNACKBAR
+        snackBarTheme: SnackBarThemeData(
+          behavior: SnackBarBehavior.floating,
+          backgroundColor: darkAppColors.primary600,
+          insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          contentTextStyle: lightAppTextStyles.bodyMediumTextStyle,
         ),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      errorStyle: TextStyle(color: lightAppColors.error),
-      filled: true,
-      fillColor: lightAppColors.neutralsWhite,
-    ),
-    navigationBarTheme: NavigationBarThemeData(
-      indicatorColor: lightAppColors.primary100,
-    ),
 
-    /// SNACKBAR
-    snackBarTheme: SnackBarThemeData(
-      behavior: SnackBarBehavior.floating,
-      backgroundColor: lightAppColors.primaryDark,
-      insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-      contentTextStyle: lightAppTextStyles.bodyMediumTextStyle.copyWith(color: lightAppColors.neutralsWhite),
-    ),
-  );
-
-    ThemeData get darkTheme => ThemeData(
-    fontFamily: FontFamily.manrope,
-
-    primaryColor: darkAppColors.primary100,
-    scaffoldBackgroundColor: darkAppColors.backgroundColor,
-    dialogBackgroundColor: Colors.black,
-
-    /// TRANSITION
-    pageTransitionsTheme: const PageTransitionsTheme(
-      builders: {
-        TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
-        TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
-      },
-    ),
-
-    /// BUTTONS
-    textButtonTheme: TextButtonThemeData(
-      style: TextButton.styleFrom(
-        backgroundColor: darkAppColors.primary100,
-        foregroundColor: darkAppColors.neutralsWhite,
-        disabledBackgroundColor: lightAppColors.primary300,
-        disabledForegroundColor: lightAppColors.primary600,
-        textStyle: darkAppTextStyles.primaryButtonTextStyle,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-        splashFactory:
-            defaultTargetPlatform == TargetPlatform.android ? InkSparkle.splashFactory : NoSplash.splashFactory,
-      ),
-    ),
-    filledButtonTheme: FilledButtonThemeData(
-      style: TextButton.styleFrom(
-        backgroundColor: darkAppColors.primary300,
-        foregroundColor: darkAppColors.neutralsWhite,
-        disabledBackgroundColor: lightAppColors.neutrals700,
-        disabledForegroundColor: lightAppColors.neutrals800,
-        textStyle: darkAppTextStyles.primaryButtonTextStyle,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-        splashFactory:
-            defaultTargetPlatform == TargetPlatform.android ? InkSparkle.splashFactory : NoSplash.splashFactory,
-      ),
-    ),
-
-    /// SPLASHES
-    splashFactory: defaultTargetPlatform == TargetPlatform.android ? InkSparkle.splashFactory : NoSplash.splashFactory,
-    splashColor: darkAppColors.primary300,
-
-    /// TEXT
-    textTheme: TextTheme(
-      titleMedium: darkAppTextStyles.titleMediumTextStyle,
-      headlineLarge: darkAppTextStyles.headlineLargeTextStyle,
-      headlineSmall: darkAppTextStyles.headlineSmallTextStyle,
-      bodyLarge: darkAppTextStyles.bodyLargeTextStyle,
-      bodyMedium: darkAppTextStyles.bodyMediumTextStyle,
-      bodySmall: darkAppTextStyles.bodySmallTextStyle,
-      labelMedium: darkAppTextStyles.labelMediumTextStyle,
-    ),
-
-    /// INPUTS
-    inputDecorationTheme: InputDecorationTheme(
-      floatingLabelStyle: TextStyle(
-        color: lightAppColors.primary100,
-      ),
-      hintStyle: TextStyle(color: lightAppColors.backgroundColor),
-      labelStyle: TextStyle(color: lightAppColors.backgroundColor),
-      contentPadding: const EdgeInsets.all(20),
-      iconColor: lightAppColors.primary100,
-      enabledBorder: OutlineInputBorder(
-        borderSide: BorderSide.none,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      focusedBorder: OutlineInputBorder(
-        borderSide: BorderSide(
-          color: darkAppColors.primary100,
+        /// APP BARS
+        appBarTheme: AppBarTheme(
+          color: darkAppColors.backgroundColor,
+          shadowColor: darkAppColors.neutrals700.withOpacity(0.8),
+          titleTextStyle: darkAppTextStyles.labelMediumTextStyle.copyWith(color: darkAppColors.primaryDark),
         ),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      errorBorder: OutlineInputBorder(
-        borderSide: BorderSide(
-          color: darkAppColors.error,
+        navigationBarTheme: NavigationBarThemeData(
+          backgroundColor: darkAppColors.backgroundColor,
+          indicatorColor: darkAppColors.primary100,
+          labelTextStyle: MaterialStateProperty.resolveWith(
+            (states) => darkAppTextStyles.bodyMediumTextStyle
+                .copyWith(color: states.contains(MaterialState.selected) ? darkAppColors.primary100 : null),
+          ),
+          iconTheme: MaterialStateProperty.resolveWith(
+            (states) => IconThemeData(color: lightAppColors.backgroundColor),
+          ),
         ),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      focusedErrorBorder: OutlineInputBorder(
-        borderSide: BorderSide(
-          color: darkAppColors.error,
-        ),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      errorStyle: TextStyle(color: darkAppColors.error),
-      filled: true,
-      fillColor: lightAppColors.neutrals900,
-    ),
-
-    /// SNACKBAR
-    snackBarTheme: SnackBarThemeData(
-      behavior: SnackBarBehavior.floating,
-      backgroundColor: darkAppColors.primary600,
-      insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-      contentTextStyle: lightAppTextStyles.bodyMediumTextStyle,
-    ),
-  );
+      );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -129,6 +129,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.6.3"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: f98972704692ba679db144261172a8e20feb145636c617af0eb4022132a6797f
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "56aa42a7a01e3c9db8456d9f3f999931f1e05535b5a424271e9a38cabf066613"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "759b9a9f8f6ccbb66c185df805fac107f05730b1dab9c64626d1008cca532257"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   characters:
     dependency: transitive
     description:
@@ -205,10 +229,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   color:
     dependency: transitive
     description:
@@ -414,6 +438,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: "8207f27539deb83732fdda03e259349046a39a4c767269285f449ade355d54ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.1"
   flutter_form_builder:
     dependency: "direct main"
     description:
@@ -622,13 +654,13 @@ packages:
     source: hosted
     version: "4.0.2"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
-      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.0"
+    version: "0.18.1"
   io:
     dependency: transitive
     description:
@@ -689,18 +721,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -725,6 +757,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "45b40f99622f11901238e18d48f5f12ea36426d8eced9f4cbf58479c7aa2430d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
@@ -974,10 +1014,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: "591f1602816e9c31377d5f008c2d9ef7b8aca8941c3f89cc5fd9d84da0c38a9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "1b92f368f44b0dee2425bb861cfa17b6f6cf3961f762ff6f941d20b33355660a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1018,6 +1074,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "5fcbd27688af6082f5abd611af56ee575342c30e87541d0245f7ff99faa02c60"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   term_glyph:
     dependency: transitive
     description:
@@ -1030,10 +1094,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   time:
     dependency: transitive
     description:
@@ -1130,6 +1194,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1179,5 +1251,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   timezone:
   equatable:
   collection:
+  intl:
+  cached_network_image:
 
   # UI
   auto_size_text: ^3.0.0


### PR DESCRIPTION
As required in #8, this PR adds trip itinerary cards.

Additionally, the following changes were made:

- implemented planner home page (to display cards)
- updated design of the app bar and navigation bar
- updated styles in theme
- added two new buttons: `TertiaryButton` and `RoundedIconButton`
- added `startDate` and `endDate` to `TripItinerary` model
- added two new packages: `intl` and `cached_network_image`
- resolve some linter problems (mostly related to package imports)